### PR TITLE
Bugfix/add phone validation to index

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,5 +63,18 @@ declare const utils: {
      * @throws {Error} An error message, if the email address is not valid.
      */
     validateEmailAddress(value: string): string;
+
+    /**
+     * Validates that a phone number matches the rules required to be
+     * accepted by GOV.UK Notify (modified slightly to allow for land-line numbers).
+     *
+     * Originally found in ``notifications_utils/recipients.py#L459-L475`, at
+     * the above repo.
+     *
+     * @param {string} phoneNumber A candidate phone number.
+     * @returns {string} The phone number, if valid.
+     * @throws {Error} An error message, if the phone number is not valid.
+     */
+    validatePhoneNumber(value: string): string;
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-utils",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-utils",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared code between NatureScot applications",
   "homepage": "https://github.com/Scottish-Natural-Heritage/naturescot-utils#readme",
   "bugs": {


### PR DESCRIPTION
Adds `validatePhoneNumber` to `index.d.ts` so it can be imported correctly. Missed in original PR.