### PR TITLE
Revert ES modules back to CommonJS modules

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -1,5 +1,5 @@
-import * as crypto from 'node:crypto';
-import {Buffer} from 'node:buffer';
+const Crypto = require('node:crypto');
+const Buffer = require('node:buffer').Buffer;
 
 const algorithm = 'aes256';
 // The key must be 32 bytes for the aes256 algorithm.
@@ -15,10 +15,10 @@ const ivLength = 16;
  * @param {string} password The password to use in encrypting the plaintext.
  * @returns {string} The encrypted text.
  */
-export const encrypt = (plaintext, password) => {
+const encrypt = (plaintext, password) => {
   const key = Buffer.from(password.slice(0, keyLength), inputEncoding);
-  const iv = crypto.randomBytes(ivLength);
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
+  const iv = Crypto.randomBytes(ivLength);
+  const cipher = Crypto.createCipheriv(algorithm, key, iv);
   const ciphered = cipher.update(plaintext, inputEncoding, outputEncoding) + cipher.final(outputEncoding);
   const ciphertext = iv.toString(outputEncoding) + ':' + ciphered;
   return ciphertext;
@@ -31,12 +31,14 @@ export const encrypt = (plaintext, password) => {
  * @param {string} password The password to use in decrypting the ciphertext.
  * @returns {string} The decrypted text.
  */
-export const decrypt = (ciphertext, password) => {
+const decrypt = (ciphertext, password) => {
   const key = Buffer.from(password.slice(0, keyLength), inputEncoding);
   const components = ciphertext.split(':');
   const ivFromCiphertext = Buffer.from(components.shift() ?? '', outputEncoding);
-  const decipher = crypto.createDecipheriv(algorithm, key, ivFromCiphertext);
+  const decipher = Crypto.createDecipheriv(algorithm, key, ivFromCiphertext);
   const deciphered =
     decipher.update(components.join(':'), outputEncoding, inputEncoding) + decipher.final(inputEncoding);
   return deciphered;
 };
+
+module.exports = {encrypt, decrypt};

--- a/crypto.test.js
+++ b/crypto.test.js
@@ -1,6 +1,6 @@
-import {Buffer} from 'node:buffer';
-import test from 'ava';
-import * as Crypto from './crypto.mjs';
+const Buffer = require('node:buffer').Buffer;
+const test = require('ava');
+const Crypto = require('./crypto.js');
 
 const encryptionKey32Bytes = 'W7EWmp213EaChaiJg1X93QdxQ9ZWHzEm';
 const encryptionKeyTooLong = 'W7EWmp213EaChaiJg1X93QdxQ9ZWHzEmFk6oU4URgqA';

--- a/formatters.js
+++ b/formatters.js
@@ -92,4 +92,4 @@ const removeWhitespace = (value) => {
   return modifiedValue;
 };
 
-export {stripAndRemoveObscureWhitespace, removeWhitespace, allWhitespace};
+module.exports = {stripAndRemoveObscureWhitespace, removeWhitespace, allWhitespace};

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
+const test = require('ava');
 
 // Import the library like a 'consumer' would.
-import * as Formatters from './formatters.mjs';
+const formatters = require('.').formatters;
 
 /**
  * This file is a translation of the `test_formatters.py` python file from
@@ -24,7 +24,7 @@ test('stripAndRemoveObscureWhitespace', (t) => {
     '\rn\u200Coti\u200Dfi\u200Bcati\u2060ons-\u180Eemai\uFEFFl\uFEFF'
   ];
   for (const value of values) {
-    t.is(Formatters.stripAndRemoveObscureWhitespace(value), 'notifications-email');
+    t.is(formatters.stripAndRemoveObscureWhitespace(value), 'notifications-email');
   }
 });
 
@@ -32,5 +32,5 @@ test('stripAndRemoveObscureWhitespace', (t) => {
 // above repo.
 test('stripAndRemoveObscureWhitespace only removes normal whitespace from ends', (t) => {
   const sentence = '   words \n over multiple lines with \ttabs\t   ';
-  t.is(Formatters.stripAndRemoveObscureWhitespace(sentence), 'words \n over multiple lines with \ttabs');
+  t.is(formatters.stripAndRemoveObscureWhitespace(sentence), 'words \n over multiple lines with \ttabs');
 });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+const crypto = require('./crypto.js');
+const formatters = require('./formatters.js');
+const recipients = require('./recipients.js');
+const postalAddress = require('./postal-address.js');
+
+module.exports = {formatters, recipients, postalAddress, crypto};

--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,0 @@
-export * as crypto from './crypto.mjs';
-export * as formatters from './formatters.mjs';
-export * as postalAddress from './postal-address.mjs';
-export * as recipients from './recipients.mjs';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturescot-utils",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared code between NatureScot applications",
   "homepage": "https://github.com/Scottish-Natural-Heritage/naturescot-utils#readme",
   "bugs": {
@@ -12,17 +12,14 @@
     "Murray Holmes <murray.holmes@nature.scot> (https://github.com/murrayholmes96)",
     "Dominic Lynch <dominic.lynch@nature.scot> (https://github.com/finchie)"
   ],
-  "type": "module",
   "files": [
     "**/*.js",
-    "**/*.mjs",
     "**/*.d.ts",
     "!**/*.test.js",
-    "!**/*.test.mjs",
     "**/*.md",
     "**/*.txt"
   ],
-  "exports": "./index.mjs",
+  "main": "./index.js",
   "repository": "github:Scottish-Natural-Heritage/naturescot-utils",
   "scripts": {
     "lint": "cspell \"**/*.js\" \"package.json\" && xo",

--- a/postal-address.js
+++ b/postal-address.js
@@ -1,4 +1,4 @@
-import * as Formatters from './formatters.mjs';
+const formatters = require('./formatters.js');
 
 /**
  * This file is a translation of the `postal_address.py` python file from
@@ -23,7 +23,7 @@ import * as Formatters from './formatters.mjs';
  * @returns {string} The postcode after being formatted with whitespace removed.
  */
 const normalisePostcode = (postcode) => {
-  return Formatters.removeWhitespace(postcode).toUpperCase();
+  return formatters.removeWhitespace(postcode).toUpperCase();
 };
 
 /**
@@ -66,4 +66,4 @@ const formatPostcodeForPrinting = (postcode) => {
   return normalised.slice(0, -3) + ' ' + normalised.slice(-3, normalised.length);
 };
 
-export {normalisePostcode, isaRealUkPostcode, formatPostcodeForPrinting};
+module.exports = {normalisePostcode, isaRealUkPostcode, formatPostcodeForPrinting};

--- a/postal-address.test.js
+++ b/postal-address.test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
+const test = require('ava');
 
 // Import the library like a 'consumer' would.
-import * as postalAddress from './postal-address.mjs';
+const postalAddress = require('.').postalAddress;
 
 /**
  * This file is a translation of the `test_postal_address.py` python file from

--- a/recipients.js
+++ b/recipients.js
@@ -1,6 +1,6 @@
-import uts46 from 'idna-uts46-hx';
+const uts46 = require('idna-uts46-hx');
 
-import * as Formatters from './formatters.mjs';
+const formatters = require('./formatters.js');
 
 /**
  * This file is a translation of the `recipients.py` python file from
@@ -84,7 +84,7 @@ const validateEmailAddress = (emailAddress) => {
   // are a lot stricter with the local part than necessary - we don't
   // allow any double quotes or semicolons to prevent SES Technical
   // Failures.
-  const trimmedEmailAddress = Formatters.stripAndRemoveObscureWhitespace(emailAddress);
+  const trimmedEmailAddress = formatters.stripAndRemoveObscureWhitespace(emailAddress);
   const match = trimmedEmailAddress.match(emailRegexPattern);
 
   // Not an email.
@@ -147,7 +147,7 @@ const validateEmailAddress = (emailAddress) => {
  * @returns {string} A formatted copy of the email address.
  */
 const formatEmailAddress = (emailAddress) => {
-  return Formatters.stripAndRemoveObscureWhitespace(emailAddress.toLowerCase());
+  return formatters.stripAndRemoveObscureWhitespace(emailAddress.toLowerCase());
 };
 
 /**
@@ -195,7 +195,7 @@ const validateInternationalPrefix = (phoneNumber) => {
  * @returns {string} Returns the normalised phone number.
  */
 const normalisePhoneNumber = (phoneNumber) => {
-  const charactersToRemove = [...Formatters.allWhitespace, '(', ')', '-', '+'];
+  const charactersToRemove = [...formatters.allWhitespace, '(', ')', '-', '+'];
 
   for (const char of charactersToRemove) {
     phoneNumber = phoneNumber.replaceAll(char, '');
@@ -307,4 +307,4 @@ const lTrim = (string, chars) => {
   return string.slice(index);
 };
 
-export {validateEmailAddress, validateAndFormatEmailAddress, validatePhoneNumber};
+module.exports = {validateEmailAddress, validateAndFormatEmailAddress, validatePhoneNumber};

--- a/recipients.test.js
+++ b/recipients.test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
+const test = require('ava');
 
 // Import the library like a 'consumer' would.
-import * as Recipients from './recipients.mjs';
+const recipients = require('.').recipients;
 
 /**
  * This file is a translation of the `test_recipient_validation.py`
@@ -40,7 +40,7 @@ test('validateEmailAddress accepts valid', (t) => {
   ];
 
   for (const emailAddress of validEmailAddresses) {
-    t.is(Recipients.validateEmailAddress(emailAddress), emailAddress);
+    t.is(recipients.validateEmailAddress(emailAddress), emailAddress);
   }
 });
 
@@ -55,7 +55,7 @@ test('validateEmailAddress strips whitespace', (t) => {
   ];
 
   for (const emailAddress of emailAddresses) {
-    t.is(Recipients.validateEmailAddress(emailAddress), 'email@domain.com');
+    t.is(recipients.validateEmailAddress(emailAddress), 'email@domain.com');
   }
 });
 
@@ -98,7 +98,7 @@ test('validateEmailAddress throws for invalid', (t) => {
 
   for (const emailAddress of invalidEmailAddresses) {
     const error = t.throws(() => {
-      Recipients.validateEmailAddress(emailAddress);
+      recipients.validateEmailAddress(emailAddress);
     });
 
     t.is(error.message, 'Not a valid email address');
@@ -141,7 +141,7 @@ test('validatePhoneNumber correctly validates valid phone numbers', (t) => {
   const validPhoneNumbers = validUkPhoneNumbers.concat(validInternationalPhoneNumbers);
 
   for (const phoneNumber of validPhoneNumbers) {
-    t.is(Recipients.validatePhoneNumber(phoneNumber), phoneNumber);
+    t.is(recipients.validatePhoneNumber(phoneNumber), phoneNumber);
   }
 });
 
@@ -168,7 +168,7 @@ test('validatePhoneNumber correctly validates invalid phone numbers', (t) => {
 
   for (const phoneNumber of invalidUkPhoneNumbersTooBig) {
     const error = t.throws(() => {
-      Recipients.validatePhoneNumber(phoneNumber);
+      recipients.validatePhoneNumber(phoneNumber);
     });
 
     t.is(error.message, 'Too many digits');
@@ -176,7 +176,7 @@ test('validatePhoneNumber correctly validates invalid phone numbers', (t) => {
 
   for (const phoneNumber of invalidUkPhoneNumbersTooSmall) {
     const error = t.throws(() => {
-      Recipients.validatePhoneNumber(phoneNumber);
+      recipients.validatePhoneNumber(phoneNumber);
     });
 
     t.is(error.message, 'Not enough digits');
@@ -184,7 +184,7 @@ test('validatePhoneNumber correctly validates invalid phone numbers', (t) => {
 
   for (const phoneNumber of invalidUkPhoneNumbersBadCharacters) {
     const error = t.throws(() => {
-      Recipients.validatePhoneNumber(phoneNumber);
+      recipients.validatePhoneNumber(phoneNumber);
     });
 
     t.is(error.message, 'Must not contain letters or symbols');


### PR DESCRIPTION
So, it turned out that upgrading consuming projects to use a shared library with ES Modules involved a fair bit of work, so I decided to revert back to CommonJS modules and leave the upgrade to ES Modules for another day!

I've already published this to npm so all that remains is to review & merge to `main`.


Issue: Scottish-Natural-Heritage/Licensing#1500